### PR TITLE
Specify Python version in Makefile

### DIFF
--- a/BeagleBone_black/Makefile
+++ b/BeagleBone_black/Makefile
@@ -50,7 +50,7 @@ $(OBJS): $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.cpp
 
 lint:
 ifndef NOLINT
-	$(Verb) python utils/Lint/presubmit.py
+	$(Verb) python2.7 utils/Lint/presubmit.py
 endif
 
 clean: cleanlint


### PR DESCRIPTION
This PR enables contributors to run the pre-commit tests if they have other python versions installed as default. 