### PR TITLE
Enable pulling automatically prebuilt images from Dockerhub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
 - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 script:
-- docker pull hyped/hyped-2018:mgt-travis
-- docker run -it hyped/hyped-2018:mgt-travis make -C BeagleBone_black -j --silent clean all
+- docker pull hyped/hyped-2018:latest
+- docker run -it hyped/hyped-2018:latest make -C BeagleBone_black -j --silent clean all
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
 - docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 script:
-- docker pull martinkristien/hyped
-- docker run -it martinkristien/hyped make -C BeagleBone_black -j --silent clean all
+- docker pull hyped/hyped-2018:mgt-travis
+- docker run -it hyped/hyped-2018:mgt-travis make -C BeagleBone_black -j --silent clean all
 
 notifications:
   slack:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM resin/beaglebone-black-debian
+RUN [ "cross-build-start" ]
 RUN apt-get update && apt-get install -y build-essential python
 RUN mkdir -p /home/au
 WORKDIR /home/au
 ADD . /home/au
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
Dockerhub continuously updates the docker image of hyped/hyped-2018:latest based on the dockerfile in this repository.