### PR TITLE
[NAV] Data fusion

### DIFF
--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -244,7 +244,20 @@ void Navigation::proximityOrientationUpdate(Proximities ground, Proximities rail
 
 void Navigation::proximityDisplacementUpdate(Proximities ground, Proximities rail)
 {
-  // TODO(Adi): Calculate displacement from proximity. (Point 7)
+  NavigationVector proxi_displ = displacement_;
+  // TODO(Brano): Make this a weighted average based on the actual positions of the 4 sensors with
+  //              respect to IMUs
+  proxi_displ[2] = (ground.fr + ground.rr + ground.rl + ground.fl) / 4.0;
+  // Change from mm to m and subtract the stationary z-axis displacement
+  // TODO(Brano): Update the z-axis displacement
+  proxi_displ[2] = proxi_displ[2]/1000.0 - 0.1;
+  // The y-axis points to the left and displacement 0 is when right and left proxis are equal
+  // TODO(Brano): Make this a weighted average based on the actual proxi positions w.r.t. IMUs
+  proxi_displ[1] = ((rail.fl - rail.fr) + (rail.rl - rail.rr)) / 2.0;
+  proxi_displ[1] = proxi_displ[1]/1000.0;
+
+  // Update displacement
+  displacement_ = (1 - settings_.prox_displ_w)*displacement_ + settings_.prox_displ_w*proxi_displ;
 }
 
 void Navigation::stripeCounterUpdate(StripeCounter sc)

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -24,6 +24,7 @@
 namespace hyped {
 namespace navigation {
 
+const Navigation::Settings Navigation::kDefaultSettings;
 float proxiMean(const Proximity* const a, const Proximity* const b)
 {
   if (a->operational && b->operational)
@@ -35,9 +36,12 @@ float proxiMean(const Proximity* const a, const Proximity* const b)
   return -1;
 }
 
-Navigation::Navigation(Barrier& post_calibration_barrier, Logger& log)
+Navigation::Navigation(Barrier& post_calibration_barrier,
+                       Logger& log,
+                       const Settings& settings)
     : post_calibration_barrier_(post_calibration_barrier),
       log_(log),
+      settings_(settings),
       status_(ModuleStatus::kStart),
       is_calibrating_(false),
       num_gravity_samples_(0),

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -282,10 +282,15 @@ void Navigation::stripeCounterUpdate(StripeCounter sc)
   }
 
   stripe_count_ = sc.count.value;
+  DataPoint<NavigationType> dp(sc.count.timestamp, kStripeLocations[stripe_count_]);
 
   // Update x-axis (forwards) displacement
-  displacement_[0] = (1 - settings_.strp_displ_w)*displacement_[0] +
-                     settings_.strp_displ_w*stripe_count_;
+  displacement_[0] = (1 - settings_.strp_displ_w) * displacement_[0] +
+                          settings_.strp_displ_w  * dp.value;
+
+  // Update x-axis velocity
+  velocity_[0] = (1 - settings_.strp_vel_w) * velocity_[0] +
+                      settings_.strp_vel_w  * stripe_differentiator_.update(dp).value;
 }
 
 }}  // namespace hyped::navigation

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -258,6 +258,15 @@ void Navigation::proximityDisplacementUpdate(Proximities ground, Proximities rai
 
   // Update displacement
   displacement_ = (1 - settings_.prox_displ_w)*displacement_ + settings_.prox_displ_w*proxi_displ;
+
+  // Update velocity
+  DataPoint<Vector<NavigationType, 2>> dp(
+      prev_angular_velocity_.timestamp,  /* IMUs always updated */
+      Vector<NavigationType, 2>({proxi_displ[1], proxi_displ[2]}));
+  auto proxi_vel = proxi_differentiator_.update(dp).value;
+
+  velocity_[1] = (1 - settings_.prox_vel_w)*velocity_[1] + settings_.prox_vel_w*proxi_vel[0];
+  velocity_[2] = (1 - settings_.prox_vel_w)*velocity_[2] + settings_.prox_vel_w*proxi_vel[1];
 }
 
 void Navigation::stripeCounterUpdate(StripeCounter sc)

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -282,6 +282,10 @@ void Navigation::stripeCounterUpdate(StripeCounter sc)
   }
 
   stripe_count_ = sc.count.value;
+
+  // Update x-axis (forwards) displacement
+  displacement_[0] = (1 - settings_.strp_displ_w)*displacement_[0] +
+                     settings_.strp_displ_w*stripe_count_;
 }
 
 }}  // namespace hyped::navigation

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -25,6 +25,7 @@
 #include "data/data.hpp"
 #include "utils/concurrent/barrier.hpp"
 #include "utils/logger.hpp"
+#include "utils/math/differentiator.hpp"
 #include "utils/math/integrator.hpp"
 #include "utils/math/kalman.hpp"
 #include "utils/math/quaternion.hpp"
@@ -43,6 +44,7 @@ using data::NavigationType;
 using data::NavigationVector;
 using utils::concurrent::Barrier;
 using utils::Logger;
+using utils::math::Differentiator;
 using utils::math::Integrator;
 using utils::math::Kalman;
 using utils::math::Quaternion;
@@ -225,6 +227,7 @@ class Navigation {
 
   Integrator<NavigationVector> acceleration_integrator_;  // Acceleration to velocity
   Integrator<NavigationVector> velocity_integrator_;      // Velocity to displacement
+  Differentiator<NavigationType> stripe_differentiator_;  // Stripe cnt distance to velocity
 };
 
 }}  // namespace hyped::navigation

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -228,6 +228,7 @@ class Navigation {
   Integrator<NavigationVector> acceleration_integrator_;  // Acceleration to velocity
   Integrator<NavigationVector> velocity_integrator_;      // Velocity to displacement
   Differentiator<NavigationType> stripe_differentiator_;  // Stripe cnt distance to velocity
+  Differentiator<Vector<NavigationType, 2>> proxi_differentiator_;
 };
 
 }}  // namespace hyped::navigation

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -63,6 +63,15 @@ class Navigation {
  public:
   typedef std::array<Imu,        Sensors::kNumImus>          ImuArray;
   typedef std::array<Proximity*, 2*Sensors::kNumProximities> ProximityArray;
+  struct Settings {
+    // TODO(Brano): Change the default values
+    float prox_orient_w = 0.1;  ///< Weight (from [0,1]) of proxi vs imu in orientation calculation
+    float prox_displ_w = 0.1;  ///< Weight (from [0,1]) of proxi vs imu in displacement calculation
+    float strp_displ_w = 1.0;  ///< Weight [0,1] of stripe count vs imu in displacement calculation
+    float prox_vel_w = 0.01;  ///< Weight (from [0,1]) of proxi vs imu in velocity calculation
+    float strp_vel_w = 0.0;  ///< Weight [0,1]  of stripe count vs imu in velocity calculation
+  };
+
   friend class Main;
 
   /**
@@ -72,7 +81,9 @@ class Navigation {
    *                                 transition to 'operational' state. It is primarily meant for
    *                                 syncing with motors module.
    */
-  explicit Navigation(Barrier& post_calibration_barrier, Logger& log = System::getLogger());
+  Navigation(Barrier& post_calibration_barrier,
+             Logger& log = System::getLogger(),
+             const Settings& settings = kDefaultSettings);
 
   /**
    * @brief Get the acceleration value
@@ -135,6 +146,7 @@ class Navigation {
   };
 
   static constexpr int kMinNumCalibrationSamples = 200000;
+  static const Settings kDefaultSettings;
   /**
    * @brief Calculates distance to the last stripe, the next stripe and the one after that.
    *
@@ -186,6 +198,7 @@ class Navigation {
   // Admin stuff
   Barrier& post_calibration_barrier_;
   Logger& log_;
+  const Settings settings_;
   ModuleStatus status_;
 
   // Calibration variables

--- a/BeagleBone_black/src/utils/math/differentiator.hpp
+++ b/BeagleBone_black/src/utils/math/differentiator.hpp
@@ -46,7 +46,7 @@ class Differentiator {
 };
 
 template <typename T>
-Differentiator<T>::Differentiator() : prev_point_(0, 0)
+Differentiator<T>::Differentiator() : prev_point_(0, T(0))
 {}
 
 template <typename T>


### PR DESCRIPTION
IMUs are quite precise over a very short time, but suffer from drift over longer time periods so we use proxi and stripe data to correct the drift.
The 8 ground proxis in 4 corners of the pod are used to estimate the z-axis (vertical) displacement and velocity. The 8 rail proxis are used to estimate y-axis (left-right) displacement and velocity, and finally, the stripe counter is used for x-axis (forwards-backwards).