### PR TITLE
Change checkVelocityZeroReached Trigger

### DIFF
--- a/BeagleBone_black/src/state_machine/main.cpp
+++ b/BeagleBone_black/src/state_machine/main.cpp
@@ -212,8 +212,8 @@ bool Main::checkFinish()
 
 bool Main::checkVelocityZeroReached()
 {
-  if (nav_data_.velocity <= 0.1) {
-    log_.INFO("STATE", "Zero velocity reached");
+  if (motor_data_.velocity_1 == 0 && motor_data_.velocity_2 == 0 && motor_data_.velocity_3 == 0 && motor_data_.velocity_4 == 0) {
+    log_.INFO("STATE", "RPM reached zero.");
     hypedMachine.handleEvent(kVelocityZeroReached);
     return true;
   }

--- a/BeagleBone_black/src/state_machine/main.cpp
+++ b/BeagleBone_black/src/state_machine/main.cpp
@@ -212,7 +212,8 @@ bool Main::checkFinish()
 
 bool Main::checkVelocityZeroReached()
 {
-  if (motor_data_.velocity_1 == 0 && motor_data_.velocity_2 == 0 && motor_data_.velocity_3 == 0 && motor_data_.velocity_4 == 0) {
+  if (motor_data_.velocity_1 == 0 && motor_data_.velocity_2 == 0
+      && motor_data_.velocity_3 == 0 && motor_data_.velocity_4 == 0) {
     log_.INFO("STATE", "RPM reached zero.");
     hypedMachine.handleEvent(kVelocityZeroReached);
     return true;


### PR DESCRIPTION
We can safely conclude that a zero RPM value implies that the pod is not moving. 