### PR TITLE
[MGT] remove PROXI, simplify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 - docker run --name travis -it hyped/hyped-2018:latest uname -a
 - docker cp . travis:/test/
 - docker commit travis hyped/current
-- docker run -it hyped/current make -C BeagleBone_black -j --silent clean all
+- docker run -it hyped/current make -C BeagleBone_black -j --silent clean hyped
 
 notifications:
   slack:

--- a/BeagleBone_black/Makefile
+++ b/BeagleBone_black/Makefile
@@ -31,6 +31,11 @@ else
 $(info cross-compiling)
 endif
 
+ifdef PROXI
+$(info using proximities)
+	CFLAGS:=$(CFLAGS) -DPROXI
+endif
+
 # test if compiler is installed
 ifeq ($(shell which $(CC)), )
 $(error compiler $(CC) is not installed)

--- a/BeagleBone_black/src/Source.files
+++ b/BeagleBone_black/src/Source.files
@@ -44,8 +44,10 @@ SRCS := \
 
 MAINS := \
   main \
+  demo_data \
   demo_machine \
   demo_motor \
+  demo_navigation \
   demo_motor_testing \
   demo_communications \
   demo_threading \
@@ -58,5 +60,8 @@ MAINS := \
   demo_can \
   demo_mpu9250 \
   demo_optical_encoder \
+  demo_sensors \
+  test_proxis \
+  demo_fake_proxis \
   demo_imus \
   test_imus \

--- a/BeagleBone_black/src/Source.files
+++ b/BeagleBone_black/src/Source.files
@@ -44,11 +44,9 @@ SRCS := \
 
 MAINS := \
   main \
-  demo_data \
   demo_machine \
   demo_motor \
   demo_motor_testing \
-  demo_navigation \
   demo_communications \
   demo_threading \
   demo_vector \
@@ -59,9 +57,6 @@ MAINS := \
   demo_statistics\
   demo_can \
   demo_mpu9250 \
-  demo_fake_proxi \
   demo_optical_encoder \
   demo_imus \
-  test_proxis \
   test_imus \
-  demo_sensors \

--- a/BeagleBone_black/src/communications/main.cpp
+++ b/BeagleBone_black/src/communications/main.cpp
@@ -104,7 +104,7 @@ int Main::sendImu(ImuArray imus)
 
   return base_communicator_->sendData("CMD09" + sen + sen1 + sen2 + sen3 + "\n");
 }
-
+#ifdef PROXI
 int Main::sendProxiFront(ProximityArray proxies_front)
 {
   std::string sen, sen1, sen2, sen3, sen4, sen5, sen6, sen7;
@@ -136,7 +136,7 @@ int Main::sendProxiRear(ProximityArray proxies_rear)
   return base_communicator_->sendData("CMD11" + sen + sen1 + sen2 + sen3 +
                                       sen4 + sen5 + sen6 + sen7 + "\n");
 }
-
+#endif
 int Main::sendEmBrakes(bool front_brakes, bool rear_brakes)
 {
   std::string brake, brake1;
@@ -237,8 +237,10 @@ void Main::run()
     if (sen_.module_status != data::ModuleStatus::kStart) {
       log_.DBG3("COMN", "Send sensors data.");
       sendImu(sen_.imu.value);
+#ifdef PROXI
       sendProxiFront(sen_.proxi_front.value);
       sendProxiRear(sen_.proxi_back.value);
+#endif
     }
 
     if (bat_.module_status != data::ModuleStatus::kStart) {

--- a/BeagleBone_black/src/communications/main.hpp
+++ b/BeagleBone_black/src/communications/main.hpp
@@ -31,7 +31,9 @@ namespace hyped {
 
 using data::Sensors;
 using data::Imu;
+#ifdef PROXI
 using data::Proximity;
+#endif
 using data::State;
 using data::Battery;
 using utils::concurrent::Thread;
@@ -42,8 +44,9 @@ namespace communications {
 class Main : public Thread {
  public:
   typedef std::array<Imu, Sensors::kNumImus>              ImuArray;
+#ifdef PROXI
   typedef std::array<Proximity, Sensors::kNumProximities> ProximityArray;
-
+#endif
   explicit Main(uint8_t id, Logger& log);
   void run() override;
   int sendDistance(NavigationType distance);                // CMD01
@@ -55,8 +58,10 @@ class Main : public Thread {
   int sendRpmBr(float rpm_br);                              // CMD07
   int sendState(State state);                               // CMD08
   int sendImu(ImuArray imus);                               // CMD09
+#ifdef PROXI
   int sendProxiFront(ProximityArray proxies_front);         // CMD10
   int sendProxiRear(ProximityArray proxies_rear);           // CMD11
+#endif
   int sendEmBrakes(bool front_brakes, bool rear_brakes);    // CMD12
   int sendHpBattery(Battery hpb);                           // CMD13-18
   int sendHpBattery_1(Battery hpb_1);                       // CMD19-24

--- a/BeagleBone_black/src/data/data.hpp
+++ b/BeagleBone_black/src/data/data.hpp
@@ -100,10 +100,11 @@ struct Imu : public Sensor {
   NavigationVector acc;
   NavigationVector gyr;
 };
-
+#ifdef PROXI
 struct Proximity : public Sensor {
   uint8_t val;
 };
+#endif
 
 struct StripeCounter : public Sensor {
   DataPoint<uint32_t> count;
@@ -111,20 +112,26 @@ struct StripeCounter : public Sensor {
 
 struct Sensors : public Module {
   static constexpr int kNumImus = 4;
+#ifdef PROXI
   static constexpr int kNumProximities = 8;
+#endif
   static constexpr int kNumKeyence = 2;
   static constexpr int kNumOptEnc = 2;
 
   DataPoint<array<Imu, kNumImus>> imu;
+#ifdef PROXI
   DataPoint<array<Proximity, kNumProximities>> proxi_front;
   DataPoint<array<Proximity, kNumProximities>> proxi_back;
+#endif
   array<StripeCounter, kNumKeyence>  keyence_stripe_counter;   //  l = 0, r = 1
   array<float, kNumOptEnc> optical_enc_distance;   // l = 0, r =1
 };
 
 struct SensorCalibration {
+#ifdef PROXI
   array<float, Sensors::kNumProximities> proxi_front_variance;
   array<float, Sensors::kNumProximities> proxi_back_variance;
+#endif
   array<array<NavigationVector, 2>, Sensors::kNumImus> imu_variance;  // x[i][0]=acc, x[i][1]=gyr
 };
 

--- a/BeagleBone_black/src/demo_integrator.cpp
+++ b/BeagleBone_black/src/demo_integrator.cpp
@@ -33,7 +33,8 @@ void print(hyped::data::DataPoint<double> x)
 
 int main()
 {
-  hyped::utils::math::Integrator<double> area;
+  hyped::data::DataPoint<double> x(0,0);
+  hyped::utils::math::Integrator<double> area(&x);
   print(area.update(a));
   print(area.update(b));
   print(area.update(c));

--- a/BeagleBone_black/src/demo_navigation.cpp
+++ b/BeagleBone_black/src/demo_navigation.cpp
@@ -133,8 +133,14 @@ int main(int argc, char* argv[])
 
     log_system.INFO("TST_NAV", "status = %d, is_calibrating = %d",
         *navs.status, *navs.is_calibrating);
-    log_system.INFO("TST_NAV", "After %7d grav samples, g=(%8.4f %8.4f %8.4f)",
-        *navs.num_gravity_samples, (*navs.g)[0], (*navs.g)[1], (*navs.g)[2]);
+    log_system.INFO("TST_NAV",
+        "After %7d grav samples, g=[(%8.4f %8.4f %8.4f), (%8.4f %8.4f %8.4f), "
+        "(%8.4f %8.4f %8.4f), (%8.4f %8.4f %8.4f)]",
+        *navs.num_gravity_samples,
+        (*navs.g)[0][0], (*navs.g)[0][1], (*navs.g)[0][2],
+        (*navs.g)[1][0], (*navs.g)[1][1], (*navs.g)[1][2],
+        (*navs.g)[2][0], (*navs.g)[2][1], (*navs.g)[2][2],
+        (*navs.g)[3][0], (*navs.g)[3][1], (*navs.g)[3][2]);
     log_system.INFO("TST_NAV",
         "After %7d gyro samples: gyro_offsets=[(%8.4f %8.4f %8.4f), (%8.4f %8.4f %8.4f), "
         "(%8.4f %8.4f %8.4f), (%8.4f %8.4f %8.4f)]",

--- a/BeagleBone_black/src/navigation/main.cpp
+++ b/BeagleBone_black/src/navigation/main.cpp
@@ -45,6 +45,7 @@ void Main::run()
   std::unique_ptr<Sensors> readings(new Sensors());
 
   // Views of the Sensors structs
+#ifdef PROXI
   std::unique_ptr<Navigation::ProximityArray> last_proxis(new Navigation::ProximityArray());
   std::unique_ptr<Navigation::ProximityArray> proxis(new Navigation::ProximityArray());
   // Set up pointers as to unify the front and rear proxis in a single array
@@ -54,6 +55,7 @@ void Main::run()
     (*last_proxis)[i] = &(last_readings->proxi_front.value[i]);
     (*last_proxis)[i + Sensors::kNumProximities] = &(last_readings->proxi_back.value[i]);
   }
+#endif
   log_.INFO("NAV", "Main started");
 
   System& sys = System::getSystem();
@@ -113,9 +115,11 @@ void Main::run()
       continue;
     }
     Navigation::Input input;
+#ifdef PROXI
      if (proxiChanged(*last_readings, *readings)) {
       input.proxis = &(*proxis);
      }
+#endif
      if (stripeCntChanged(*last_readings, *readings)) {
       input.sc = &readings->keyence_stripe_counter;
      }
@@ -130,7 +134,9 @@ void Main::run()
     updateData();
 
     readings.swap(last_readings);
+#ifdef PROXI
     proxis.swap(last_proxis);
+#endif
   }
 }
 
@@ -145,12 +151,14 @@ bool Main::imuChanged(const Sensors& old_data, const Sensors& new_data)
   return new_data.imu.timestamp != old_data.imu.timestamp;
 }
 
+#ifdef PROXI
 bool Main::proxiChanged(const Sensors& old_data, const Sensors& new_data)
 {
   // Both front and back should be always updated at the same time
   return old_data.proxi_front.timestamp != new_data.proxi_front.timestamp &&
          old_data.proxi_back.timestamp  != new_data.proxi_back.timestamp;
 }
+#endif
 
 inline bool Main::stripeCntChanged(const Sensors& old_data, const Sensors& new_data)
 {

--- a/BeagleBone_black/src/navigation/main.cpp
+++ b/BeagleBone_black/src/navigation/main.cpp
@@ -188,8 +188,8 @@ void Main::updateData()
       "Update: ms=%d, a=(%.2f, %.2f, %.2f), v=(%.2f, %.2f, %.2f), d=(%.2f, %.2f, %.2f), bd=%.2f, ebd=%.2f", //NOLINT
       nav_.status_,
       nav_.acceleration_[0], nav_.acceleration_[1], nav_.acceleration_[2],
-      nav_.velocity_[0], nav_.velocity_[1], nav_.velocity_[2],
-      nav_.displacement_[0], nav_.displacement_[1], nav_.displacement_[2],
+      nav_.velocity_.value[0], nav_.velocity_.value[1], nav_.velocity_.value[2],
+      nav_.displacement_.value[0], nav_.displacement_.value[1], nav_.displacement_.value[2],
       nav_.getBrakingDistance(), nav_.getEmergencyBrakingDistance());
 }
 

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -123,12 +123,11 @@ NavigationType Navigation::getEmergencyBrakingDistance() const
 NavigationType Navigation::getBrakingDistance() const
 {
   // A polynomial fit for the braking distance at a specific (normalised) velocity
-  static constexpr std::array<NavigationType, 16> kCoefficients = {80.7074,
-            93.8803,   10.6627,   -9.2234,  180.2587,  124.2188, -495.1209, -428.6747,
-           568.6541,  657.6976, -196.3143, -437.5374,  -78.3606,   95.7824,   49.3553,
-             6.9888};
+  static constexpr std::array<NavigationType, 16> kCoefficients = {
+       136.3132, 158.9403,  63.6093, -35.4894, -149.2755, 152.6967, 502.5464, -218.4689,
+      -779.534,   95.7285, 621.1013,  50.4598, -245.099,  -54.5,     38.0642,   12.3548};
 
-  NavigationType norm_v = (getVelocity() - 45.5628) / 21.9511;
+  NavigationType norm_v = (getVelocity() - 30.0079) / 17.2325;
   NavigationType var = 1.0;
   NavigationType braking_distance = 2.0;
   for (unsigned int i = 0; i < kCoefficients.size(); ++i) {

--- a/BeagleBone_black/src/navigation/navigation.cpp
+++ b/BeagleBone_black/src/navigation/navigation.cpp
@@ -21,9 +21,12 @@
 #include <algorithm>  // std::min
 #include <map>
 #include <string>
+#include <sstream>
 
+#ifdef PROXI
 #include "Eigen/Dense"
 #include "Eigen/SVD"
+#endif
 
 namespace hyped {
 namespace navigation {

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -84,6 +84,11 @@ class Navigation {
   typedef std::array<Proximity*,    2*Sensors::kNumProximities> ProximityArray;
   typedef std::array<StripeCounter, Sensors::kNumKeyence>       StripeCounterArray;
   struct Settings {
+    bool proxi_displ_enable = false;  // Needs updated proxi positions
+    bool proxi_orient_enable = false;  // Needs updated proxi positions
+    bool gyro_enable = false;  // Not fully implemented (rotate a)
+    bool opt_enc_enable = false;  // Not implemented
+    bool keyence_enable = true;
     // TODO(Brano): Change the default values
     float prox_orient_w = 0.1;  ///< Weight (from [0,1]) of proxi vs imu in orientation calculation
     float prox_displ_w = 0.1;  ///< Weight (from [0,1]) of proxi vs imu in displacement calculation

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -255,8 +255,8 @@ class Navigation {
 
   // Most up-to-date values of pod's acceleration, velocity and displacement in 3D; used for output
   NavigationVector acceleration_;
-  NavigationVector velocity_;
-  NavigationVector displacement_;
+  DataPoint<NavigationVector> velocity_;
+  DataPoint<NavigationVector> displacement_;
   uint16_t stripe_count_;
 
   // Internal data that is not published

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -106,7 +106,7 @@ class Navigation {
     const ModuleStatus*     status;
     const bool*             is_calibrating;
     const int*              num_gravity_samples;
-    const NavigationVector* g;  // Acceleration due to gravity. Measured during calibration.
+    const std::array<NavigationVector, Sensors::kNumImus>* g;  // Acc offsets (gravitational acc)
     const int*              num_gyro_samples;
     const std::array<NavigationVector, Sensors::kNumImus>* gyro_offsets;
 
@@ -254,7 +254,7 @@ class Navigation {
   // Calibration variables
   bool is_calibrating_;
   int num_gravity_samples_;
-  NavigationVector g_;  // Acceleration due to gravity. Measured during calibration.
+  std::array<NavigationVector, Sensors::kNumImus> g_;  // Acc offsets (gravitational acc)
   int num_gyro_samples_;
   std::array<NavigationVector, Sensors::kNumImus> gyro_offsets_;  // Measured during calibration
 

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -42,7 +42,9 @@ using data::Imu;
 using data::ModuleStatus;
 using data::NavigationType;
 using data::NavigationVector;
+#ifdef PROXI
 using data::Proximity;
+#endif
 using data::SensorCalibration;
 using data::Sensors;
 using data::StripeCounter;
@@ -81,7 +83,9 @@ class Navigation {
 
  public:
   typedef std::array<Imu,           Sensors::kNumImus>          ImuArray;
+#ifdef PROXI
   typedef std::array<Proximity*,    2*Sensors::kNumProximities> ProximityArray;
+#endif
   typedef std::array<StripeCounter, Sensors::kNumKeyence>       StripeCounterArray;
   struct Settings {
     bool proxi_displ_enable = false;  // Needs updated proxi positions
@@ -98,7 +102,9 @@ class Navigation {
   };
   struct Input {
     DataPoint<ImuArray> *imus = nullptr;
+#ifdef PROXI
     ProximityArray *proxis = nullptr;
+#endif
     StripeCounterArray *sc = nullptr;
     array<float, Sensors::kNumOptEnc> *optical_enc_distance = nullptr;
   };
@@ -205,12 +211,14 @@ class Navigation {
    *        likely temporary and will be replaced by an array or other suitable data structure once
    *        the algorithm using it is complete.
    */
+  #ifdef PROXI
   struct Proximities {
     float fr;  // mm
     float rr;  // mm
     float rl;  // mm
     float fl;  // mm
   };
+#endif
 
   static constexpr int kMinNumCalibrationSamples = 200000;
   static const Settings kDefaultSettings;
@@ -234,12 +242,16 @@ class Navigation {
    */
 
   void imuUpdate(DataPoint<ImuArray> imus);
+#ifdef PROXI
   void proximityUpdate(ProximityArray proxis);
+#endif
   void calibrationUpdate(ImuArray imus);
   void gyroUpdate(DataPoint<NavigationVector> angular_velocity);  // Point number 1
   void accelerometerUpdate(DataPoint<NavigationVector> acceleration);  // Points 3, 4, 5, 6
+#ifdef PROXI
   void proximityOrientationUpdate(Proximities ground, Proximities rail);  // Point number 7
   void proximityDisplacementUpdate(Proximities ground, Proximities rail);  // Point number 7
+#endif
   void stripeCounterUpdate(StripeCounterArray scs);  // Point number 7
   void opticalEncoderUpdate(array<float, Sensors::kNumOptEnc> optical_enc_distance);
   void readDataFromFile(std::string file_path);
@@ -271,12 +283,15 @@ class Navigation {
   // Filters for reducing noise in sensor data before processing the data in any other way
   std::array<Kalman<NavigationVector>, Sensors::kNumImus> acceleration_filter_;  // One for each IMU
   std::array<Kalman<NavigationVector>, Sensors::kNumImus> gyro_filter_;          // One for each IMU
+#ifdef PROXI
   std::array<Kalman<float>, 2*Sensors::kNumProximities> proximity_filter_;
-
+#endif
   Integrator<NavigationVector> acceleration_integrator_;  // Acceleration to velocity
   Integrator<NavigationVector> velocity_integrator_;      // Velocity to displacement
   Differentiator<NavigationType> stripe_differentiator_;  // Stripe cnt distance to velocity
+#ifdef PROXI
   Differentiator<Vector<NavigationType, 2>> proxi_differentiator_;
+#endif
 };
 
 }}  // namespace hyped::navigation

--- a/BeagleBone_black/src/navigation/navigation.hpp
+++ b/BeagleBone_black/src/navigation/navigation.hpp
@@ -88,8 +88,10 @@ class Navigation {
 #endif
   typedef std::array<StripeCounter, Sensors::kNumKeyence>       StripeCounterArray;
   struct Settings {
+#ifdef PROXI
     bool proxi_displ_enable = false;  // Needs updated proxi positions
     bool proxi_orient_enable = false;  // Needs updated proxi positions
+#endif
     bool gyro_enable = false;  // Not fully implemented (rotate a)
     bool opt_enc_enable = false;  // Not implemented
     bool keyence_enable = true;
@@ -211,7 +213,7 @@ class Navigation {
    *        likely temporary and will be replaced by an array or other suitable data structure once
    *        the algorithm using it is complete.
    */
-  #ifdef PROXI
+#ifdef PROXI
   struct Proximities {
     float fr;  // mm
     float rr;  // mm

--- a/BeagleBone_black/src/sensors/can_proxi.cpp
+++ b/BeagleBone_black/src/sensors/can_proxi.cpp
@@ -19,6 +19,7 @@
  *    limitations under the License.
  */
 
+#ifdef PROXI
 #include "sensors/can_proxi.hpp"
 
 
@@ -112,4 +113,4 @@ bool CanProxi::hasId(uint32_t id, bool extended)
 
 
 }}  // namespace hyped::sensors
-
+#endif

--- a/BeagleBone_black/src/sensors/can_proxi.hpp
+++ b/BeagleBone_black/src/sensors/can_proxi.hpp
@@ -21,6 +21,7 @@
 
 #ifndef BEAGLEBONE_BLACK_SENSORS_CAN_PROXI_HPP_
 #define BEAGLEBONE_BLACK_SENSORS_CAN_PROXI_HPP_
+#ifdef PROXI
 
 #include <cstdint>
 
@@ -73,6 +74,6 @@ class CanProxi : public ProxiInterface, public CanProccesor {
 };
 
 }}  // namespace hyped::sensors
-
+#endif
 #endif  // BEAGLEBONE_BLACK_SENSORS_CAN_PROXI_HPP_
 

--- a/BeagleBone_black/src/sensors/fake_proxi.cpp
+++ b/BeagleBone_black/src/sensors/fake_proxi.cpp
@@ -17,7 +17,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
+#ifdef PROXI
 #include "sensors/fake_proxi.hpp"
 
 #include <random>
@@ -159,4 +159,4 @@ bool FakeProxi::checkTime()
 }
 
 }}   // namespace hyped::sensors
-
+#endif

--- a/BeagleBone_black/src/sensors/fake_proxi.hpp
+++ b/BeagleBone_black/src/sensors/fake_proxi.hpp
@@ -22,7 +22,7 @@
 
 #ifndef BEAGLEBONE_BLACK_SENSORS_FAKE_PROXI_HPP_
 #define BEAGLEBONE_BLACK_SENSORS_FAKE_PROXI_HPP_
-
+#ifdef PROXI
 #include <string>
 #include <vector>
 
@@ -104,5 +104,5 @@ class FakeProxi : public ProxiInterface {
 
 }}  // namespace hyped::sensors
 
-
+#endif
 #endif  // BEAGLEBONE_BLACK_SENSORS_FAKE_PROXI_HPP_

--- a/BeagleBone_black/src/sensors/interface.hpp
+++ b/BeagleBone_black/src/sensors/interface.hpp
@@ -27,7 +27,9 @@
 namespace hyped {
 
 using data::Imu;
+#ifdef PROXI
 using data::Proximity;
+#endif
 using data::Battery;
 using data::NavigationVector;
 
@@ -41,7 +43,7 @@ class SensorInterface {
    */
   virtual bool isOnline() = 0;
 };
-
+#ifdef PROXI
 class ProxiInterface: public SensorInterface {
  public:
   /**
@@ -51,6 +53,7 @@ class ProxiInterface: public SensorInterface {
   virtual void getData(Proximity* proxi) = 0;
   virtual void startRanging() = 0;
 };
+#endif
 
 class ImuInterface: public SensorInterface {
  public:

--- a/BeagleBone_black/src/sensors/main.hpp
+++ b/BeagleBone_black/src/sensors/main.hpp
@@ -71,8 +71,10 @@ class Main: public Thread {
   GpioInterface*                         keyence_l_;
   GpioInterface*                         keyence_r_;
   std::unique_ptr<ImuManagerInterface>   imu_manager_;
+  #ifdef PROXI
   std::unique_ptr<ProxiManagerInterface> proxi_manager_front_;
   std::unique_ptr<ProxiManagerInterface> proxi_manager_back_;
+  #endif
   std::unique_ptr<ManagerInterface>      battery_manager_;
   GpioInterface*                         optical_encoder_l_;
   GpioInterface*                         optical_encoder_r_;

--- a/BeagleBone_black/src/sensors/manager_interface.hpp
+++ b/BeagleBone_black/src/sensors/manager_interface.hpp
@@ -27,7 +27,9 @@
 namespace hyped {
 
 using data::Imu;
+#ifdef PROXI
 using data::Proximity;
+#endif
 using data::Battery;
 using utils::concurrent::Thread;
 using data::NavigationVector;
@@ -52,13 +54,13 @@ class ImuManagerInterface : public ManagerInterface {
   ImuManagerInterface(utils::Logger& log) : ManagerInterface(log) {}
   virtual array<array<NavigationVector, 2>, data::Sensors::kNumImus> getCalibrationData() = 0;
 };
-
+#ifdef PROXI
 class ProxiManagerInterface : public ManagerInterface {
  public:
   ProxiManagerInterface(utils::Logger& log) : ManagerInterface(log) {}
   virtual array<float, data::Sensors::kNumProximities> getCalibrationData() = 0;
 };
-
+#endif
 }}  // namespace hyped::sensors
 
 #endif  // BEAGLEBONE_BLACK_SENSORS_MANAGER_INTERFACE_HPP_

--- a/BeagleBone_black/src/sensors/proxi_manager.cpp
+++ b/BeagleBone_black/src/sensors/proxi_manager.cpp
@@ -18,6 +18,7 @@
  *    limitations under the License.
  */
 
+#ifdef PROXI
 #include "sensors/proxi_manager.hpp"
 
 #include "sensors/can_proxi.hpp"
@@ -147,3 +148,4 @@ void ProxiManager::resetTimestamp()
   old_timestamp_ = sensors_proxi_->timestamp;
 }
 }}  // namespace hyped::sensors
+#endif

--- a/BeagleBone_black/src/sensors/proxi_manager.hpp
+++ b/BeagleBone_black/src/sensors/proxi_manager.hpp
@@ -20,6 +20,7 @@
 
 #ifndef BEAGLEBONE_BLACK_SENSORS_PROXI_MANAGER_HPP_
 #define BEAGLEBONE_BLACK_SENSORS_PROXI_MANAGER_HPP_
+#ifdef PROXI
 
 #include <cstdint>
 
@@ -65,5 +66,5 @@ class ProxiManager: public ProxiManagerInterface {
 };
 
 }}  // namespace hyped::sensors
-
+#endif
 #endif  // BEAGLEBONE_BLACK_SENSORS_PROXI_MANAGER_HPP_

--- a/BeagleBone_black/src/sensors/vl6180.cpp
+++ b/BeagleBone_black/src/sensors/vl6180.cpp
@@ -17,6 +17,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#ifdef PROXI
 #include "sensors/vl6180.hpp"
 
 #include <cstdint>
@@ -321,3 +322,5 @@ bool VL6180::writeByte(uint16_t reg_add, char data)
 }
 
 }}   // namespace hyped::sensors
+
+#endif

--- a/BeagleBone_black/src/sensors/vl6180.hpp
+++ b/BeagleBone_black/src/sensors/vl6180.hpp
@@ -18,8 +18,10 @@
  *    limitations under the License.
  */
 
+
 #ifndef BEAGLEBONE_BLACK_SENSORS_VL6180_HPP_
 #define BEAGLEBONE_BLACK_SENSORS_VL6180_HPP_
+#ifdef  PROXI
 
 #include "sensors/interface.hpp"
 #include "utils/logger.hpp"
@@ -91,6 +93,6 @@ class VL6180: public ProxiInterface {
 };
 
 }}  // namespace hyped::sensors
-
+#endif
 
 #endif  // BEAGLEBONE_BLACK_SENSORS_VL6180_HPP_

--- a/BeagleBone_black/src/utils/math/differentiator.hpp
+++ b/BeagleBone_black/src/utils/math/differentiator.hpp
@@ -56,6 +56,7 @@ DataPoint<T> Differentiator<T>::update(DataPoint<T> point)
   if (!initialised_) {
     prev_point_ = point;
     initialised_ = true;
+    return DataPoint<T>(point.timestamp, T(0));
   }
   // Assume timestamp in microseconds and convert to seconds
   T gradient = (point.value - prev_point_.value) / ((point.timestamp - prev_point_.timestamp)/1e6);

--- a/BeagleBone_black/src/utils/math/integrator.hpp
+++ b/BeagleBone_black/src/utils/math/integrator.hpp
@@ -28,10 +28,21 @@ namespace math {
 
 using hyped::data::DataPoint;
 
+/**
+ * @brief Calculates an integral. Supports shared output variables that are modifiable by other code
+ *        as well.
+ *
+ * @tparam T Underlying numeric type
+ */
 template <typename T>
 class Integrator {
  public:
-  Integrator();
+  /**
+   * @brief Construct a new Integrator object
+   *
+   * @param output Where the result is stored. Caller is responsible for freeing the memory
+   */
+  explicit Integrator(DataPoint<T>* output);
 
   /**
    * @brief    Calculates the area given two points for time T_(N)
@@ -43,13 +54,13 @@ class Integrator {
 
  private:
   DataPoint<T> previous_point_;
-  DataPoint<T> previous_output_;
+  DataPoint<T>* output_;
   bool initialised_;
 };
 
 template <typename T>
-Integrator<T>::Integrator()
-    : previous_point_(0, T(0)), previous_output_(0, T(0)), initialised_(false)
+Integrator<T>::Integrator(DataPoint<T>* output)
+    : previous_point_(0, T(0)), output_(output), initialised_(false)
 {}
 
 template <typename T>
@@ -64,12 +75,12 @@ DataPoint<T> Integrator<T>::update(const DataPoint<T>& point)
   T area = (point.value + previous_point_.value)/2 *
            ((point.timestamp - previous_point_.timestamp)/1e6);
 
-  previous_output_.value += area;
-  previous_output_.timestamp = point.timestamp;
+  output_->value += area;
+  output_->timestamp = point.timestamp;
 
   previous_point_ = point;
 
-  return previous_output_;
+  return *output_;
 }
 
 }}}  // hyped::utils::math

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,4 +2,4 @@
 
 echo "Running pre-commit hook"
 
-make -C BeagleBone_black all -j --silent
+make -C BeagleBone_black -j --silent


### PR DESCRIPTION
Travis should run test only as `make` instead of `make all`
The same applies for git commit hook, you need to `./setup.sh` again though.

Proximities are not being used throughout the system. Just recompile to apply the effects. If you want to reenable proxi use, run `make PROXI=1`.